### PR TITLE
Klipper configuration improvement

### DIFF
--- a/firmware/printer.cfg
+++ b/firmware/printer.cfg
@@ -1,3 +1,5 @@
+[include mainsail.cfg]
+
 # This file contains common pin mappings for the Fysetc R4 V1.0
 # To use this config, the firmware should be compiled for the RP2040 with
 # USB communication.
@@ -22,7 +24,7 @@
 #####################################################################
 # Obtain definition by "ls -l /dev/serial/by-id/"
 #####################################################################
-serial: /dev/serial/by-id/usb-Klipper_rp2040_REPLACE_WITH_YOUR_VALUE
+serial: /dev/serial/by-id/usb-Klipper_rp2040_E661AC88631B9128-if00
 restart_method: command
 
 [printer]
@@ -45,7 +47,7 @@ enable_pin: !gpio4
 rotation_distance: 40
 microsteps: 32
 full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
-endstop_pin: ^!gpio11
+endstop_pin: ^gpio11
 position_endstop: 120
 position_max: 120
 homing_speed: 50                                                    # Can be increased after initial setup, Max 100
@@ -64,12 +66,12 @@ stealthchop_threshold: 0                                            # Set to 999
 [stepper_y]
 step_pin: gpio16
 ## Refer to https://docs.vorondesign.com/build/startup/#v0
-dir_pin: !gpio15                                                    # Check motor direction in link above. If inverted, add a ! before gpio5
+dir_pin: !gpio15                                                      # Check motor direction in link above. If inverted, add a ! before gpio5
 enable_pin: !gpio14
 rotation_distance: 40
 microsteps: 32
 full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
-endstop_pin: ^!gpio12
+endstop_pin: ^gpio12
 position_endstop: 120
 position_max: 120
 homing_speed: 50                                                    # Can be increased after initial setup, Max 100
@@ -95,7 +97,7 @@ dir_pin: !gpio18                                                    # Remove the
 enable_pin: !gpio17
 rotation_distance: 8                                                # For T8x8 integrated lead screw
 microsteps: 32
-endstop_pin: ^gpio25
+endstop_pin: ^!gpio13
 position_endstop: -0.10
 position_max: 120
 position_min: -1.5
@@ -111,7 +113,7 @@ interpolate: False
 ## For OMC (StepperOnline) 17LS13-0404E-200G 0.4A 
 #run_current: 0.2
 ## For LDO-42STH25-1004CL200E 1.0A
-#run_current: 0.37
+run_current: 0.37
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
@@ -132,7 +134,7 @@ filament_diameter: 1.750
 heater_pin: gpio24
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-#sensor_type:
+sensor_type: ATC Semitec 104NT-4-R025H42G
 sensor_pin: gpio28
 control: pid                                                        # Do PID calibration after initial checks
 pid_Kp: 28.182
@@ -156,7 +158,7 @@ interpolate: False
 ## For LDO LDO 36STH17-1004AHG 1A 1.8° 
 #run_current: 0.3 # for LDO 36STH17-1004AHG
 ## For LDO LDO 36STH20-1004AHG 1A 1.8° 
-#run_current: 0.6 # for LDO 36STH20-1004AHG
+run_current: 0.6 # for LDO 36STH20-1004AHG
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 
@@ -168,7 +170,7 @@ stealthchop_threshold: 0                                            # Set to 0 f
 heater_pin: gpio23
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-#sensor_type:
+sensor_type: Generic 3950
 sensor_pin: gpio26
 smooth_time: 3.0
 #max_power: 0.6                                                     # Only needed for 100w pads
@@ -271,7 +273,7 @@ pause_on_runout: True
 [temperature_sensor chamber]
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-#sensor_type:
+sensor_type: Generic 3950
 sensor_pin: gpio27
 #min_temp:
 #max_temp:
@@ -340,4 +342,5 @@ gcode:
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
 
-[include mainsail.cfg]
+[force_move]
+enable_force_move: True

--- a/firmware/printer.cfg
+++ b/firmware/printer.cfg
@@ -262,19 +262,19 @@ screw3_name: back right
 # Filament Sensor
 #####################################################################
 
-[filament_switch_sensor runout_sensor]
-switch_pin: ^gpio10
-pause_on_runout: True
+#[filament_switch_sensor runout_sensor]
+#switch_pin: ^gpio10
+#pause_on_runout: True
 
 #####################################################################
 # Chamber Temperature Sensor
 #####################################################################
 
-[temperature_sensor chamber]
+#[temperature_sensor chamber]
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type: Generic 3950
-sensor_pin: gpio27
+#sensor_type: Generic 3950
+#sensor_pin: gpio27
 #min_temp:
 #max_temp:
 

--- a/firmware/printer.cfg
+++ b/firmware/printer.cfg
@@ -64,7 +64,7 @@ stealthchop_threshold: 0                                            # Set to 999
 [stepper_y]
 step_pin: gpio16
 ## Refer to https://docs.vorondesign.com/build/startup/#v0
-dir_pin: !gpio15                                                      # Check motor direction in link above. If inverted, add a ! before gpio5
+dir_pin: !gpio15                                                    # Check motor direction in link above. If inverted, add a ! before gpio5
 enable_pin: !gpio14
 rotation_distance: 40
 microsteps: 32
@@ -79,7 +79,7 @@ homing_positive_dir: true
 [tmc2209 stepper_y]
 uart_pin: gpio9
 tx_pin: gpio8
-uart_address: 2
+uart_address: 1
 interpolate: False
 run_current: 0.5
 sense_resistor: 0.110
@@ -106,7 +106,7 @@ homing_retract_dist: 3.0
 [tmc2209 stepper_z]
 uart_pin: gpio9
 tx_pin: gpio8
-uart_address: 1
+uart_address: 2
 interpolate: False
 ## For OMC (StepperOnline) 17LS13-0404E-200G 0.4A 
 #run_current: 0.2

--- a/firmware/printer.cfg
+++ b/firmware/printer.cfg
@@ -24,7 +24,7 @@
 #####################################################################
 # Obtain definition by "ls -l /dev/serial/by-id/"
 #####################################################################
-serial: /dev/serial/by-id/usb-Klipper_rp2040_E661AC88631B9128-if00
+serial: /dev/serial/by-id/usb-Klipper_rp2040_REPLACE_WITH_YOUR_VALUE
 restart_method: command
 
 [printer]
@@ -59,7 +59,7 @@ uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 0
 interpolate: False
-run_current: 0.5
+run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
@@ -83,7 +83,7 @@ uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 1
 interpolate: False
-run_current: 0.5
+run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 

--- a/firmware/printer.cfg
+++ b/firmware/printer.cfg
@@ -1,23 +1,54 @@
-[include mainsail.cfg]
+# This file contains common pin mappings for the Fysetc R4 V1.0
+# To use this config, the firmware should be compiled for the RP2040 with
+# USB communication.
+
+# The "make flash" command does not work on the R4 V1.0. Instead,
+# after running "make", copy the generated "out/klipper.uf2" file
+# to the mass storage device in RP2040 boot mode
+
+## Voron Design VORON 0.1 R4 V1.0 config
+
+## *** THINGS TO CHANGE/CHECK: ***
+## MCU path                                                                     [mcu] section
+## Z and Extruder motor currents                                                [tmc2209 stepper_*] sections. Uncomment the stepper motor you have
+## Full steps per rotation for Extruder                                         [extruder] section
+## Thermistor types                                                             [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
+## Extruder motor currents                                                      [extruder] section
+## PID tune                                                                     [extruder] and [heater_bed] sections
+## Fine tune E steps                                                            [extruder] section
+## For more info                                                                check https://docs.vorondesign.com/build/startup/#v0
 
 [mcu]
-##	Obtain mcu value by "ls -l /dev/serial/by-id/" 
-serial: /dev/serial/by-id/usb-Klipper_rp2040_E16044B34B343525-if00
-#serial: /dev/ttyAMA0
+#####################################################################
+# Obtain definition by "ls -l /dev/serial/by-id/"
+#####################################################################
+serial: /dev/serial/by-id/usb-Klipper_rp2040_REPLACE_WITH_YOUR_VALUE
 restart_method: command
+
+[printer]
+kinematics: corexy
+max_velocity: 200
+max_accel: 2000
+max_z_velocity: 15
+max_z_accel: 45
+square_corner_velocity: 6.0
+
+#####################################################################
+#      X/Y Stepper Settings
+#####################################################################
 
 [stepper_x]
 step_pin: gpio3
-dir_pin: !gpio2
+## Refer to https://docs.vorondesign.com/build/startup/#v0
+dir_pin: !gpio2                                                     # Check motor direction in link above. If inverted, add a ! before gpio10
 enable_pin: !gpio4
 rotation_distance: 40
-microsteps: 16
+microsteps: 32
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
 endstop_pin: ^!gpio11
-# endstop_pin: tmc2209_stepper_x:virtual_endstop
-# 
 position_endstop: 120
 position_max: 120
-homing_speed: 50
+homing_speed: 50                                                    # Can be increased after initial setup, Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
@@ -25,142 +56,172 @@ homing_positive_dir: true
 uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 0
-interpolate: True
-run_current: 0.8
-hold_current: 0.6
+interpolate: False
+run_current: 0.5
 sense_resistor: 0.110
-stealthchop_threshold: 999999
-# diag_pin: ^gpio11
-# driver_SGTHRS: 100
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 [stepper_y]
 step_pin: gpio16
-dir_pin: !gpio15
+## Refer to https://docs.vorondesign.com/build/startup/#v0
+dir_pin: !gpio15                                                      # Check motor direction in link above. If inverted, add a ! before gpio5
 enable_pin: !gpio14
 rotation_distance: 40
-microsteps: 16
+microsteps: 32
+full_steps_per_rotation: 200                                        # Set to 400 for 0.9° degree stepper motor, 200 is for 1.8° stepper motors
 endstop_pin: ^!gpio12
-# endstop_pin: tmc2209_stepper_y:virtual_endstop
 position_endstop: 120
 position_max: 120
-homing_speed: 50
+homing_speed: 50                                                    # Can be increased after initial setup, Max 100
 homing_retract_dist: 5
+homing_positive_dir: true
 
 [tmc2209 stepper_y]
 uart_pin: gpio9
 tx_pin: gpio8
-uart_address: 1
-run_current: 0.8
-hold_current: 0.6
+uart_address: 2
+interpolate: False
+run_current: 0.5
 sense_resistor: 0.110
-stealthchop_threshold: 999999
-#diag_pin: ^gpio12
-#driver_SGTHRS: 100
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+
+#####################################################################
+#   Z Stepper Settings
+#####################################################################
 
 [stepper_z]
 step_pin: gpio19
-dir_pin: !gpio18
+dir_pin: !gpio18                                                    # Remove the ! before gpio28 if motor direction is inverted.
 enable_pin: !gpio17
-rotation_distance: 8 #for T8x8 lead screw
-microsteps: 16
-rotation_distance: 8
-endstop_pin: ^!gpio13
-position_endstop: 0
-#endstop_pin: probe:z_virtual_endstop
-position_min: -1.0
-position_max: 250
-homing_speed: 12
+rotation_distance: 8                                                # For T8x8 integrated lead screw
+microsteps: 32
+endstop_pin: ^gpio25
+position_endstop: -0.10
+position_max: 120
+position_min: -1.5
+homing_speed: 10
 second_homing_speed: 3.0
 homing_retract_dist: 3.0
 
 [tmc2209 stepper_z]
 uart_pin: gpio9
 tx_pin: gpio8
-uart_address: 2
-run_current: 0.580
-hold_current: 0.500
-stealthchop_threshold: 999999
+uart_address: 1
+interpolate: False
+## For OMC (StepperOnline) 17LS13-0404E-200G 0.4A 
+#run_current: 0.2
+## For LDO-42STH25-1004CL200E 1.0A
+#run_current: 0.37
+sense_resistor: 0.110
+stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
+
+#####################################################################
+#   Extruder
+#####################################################################
 
 [extruder]
 step_pin: gpio6
-dir_pin: !gpio5
+dir_pin: !gpio5                                                     # Add ! if moving opposite direction
 enable_pin: !gpio7
-full_steps_per_rotation: 200    # 1.8 degree motor
-rotation_distance: 22.23        # See calibrating rotation_distance on extruders doc
-gear_ratio: 50:10               # For Mini Afterburner
-microsteps: 16
-rotation_distance: 33.500
-nozzle_diameter: 0.4
-filament_diameter: 1.75
+#full_steps_per_rotation: 200                                       # Set to 200 for LDO 1.8° stepper motor, and set to 400 for OMC(StepperOnline) 0.9° stepper motor
+rotation_distance: 22.23                                            # See calibrating rotation_distance on extruders doc
+gear_ratio: 50:10                                                   # For Mini Afterburner
+microsteps: 32
+nozzle_diameter: 0.400
+filament_diameter: 1.750
 heater_pin: gpio24
-sensor_type: EPCOS 100K B57560G104F
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+#sensor_type:
 sensor_pin: gpio28
-control: pid
-pid_Kp: 22.2
-pid_Ki: 1.08
-pid_Kd: 114
+control: pid                                                        # Do PID calibration after initial checks
+pid_Kp: 28.182
+pid_Ki: 1.978
+pid_Kd: 100.397
 min_temp: 0
-max_temp: 300
+max_temp: 270
 min_extrude_temp: 170
-max_extrude_only_distance: 780.0
-max_extrude_cross_section:2
-pressure_advance: 0.0   # See tuning pressure advance doc
+max_extrude_only_distance: 150
+max_extrude_cross_section: 0.8
+pressure_advance: 0.0                                               # See tuning pressure advance doc
 pressure_advance_smooth_time: 0.040
 
 [tmc2209 extruder]
 uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 3
-interpolate: True
-run_current: 0.650
-hold_current: 0.500
-stealthchop_threshold: 999999
+interpolate: False
+## For OMC (StepperOnline) 14HR07-1004VRN 1A 0.9°
+#run_current: 0.5 # for OMC 14HR07-1004VRN rated at 1A
+## For LDO LDO 36STH17-1004AHG 1A 1.8° 
+#run_current: 0.3 # for LDO 36STH17-1004AHG
+## For LDO LDO 36STH20-1004AHG 1A 1.8° 
+#run_current: 0.6 # for LDO 36STH20-1004AHG
+sense_resistor: 0.110
+stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 
-[filament_switch_sensor runout_sensor]
-switch_pin: ^gpio10
-pause_on_runout: True
-
-# [filament_motion_sensor smart_sensor]
-# switch_pin: ^gpio10
-# detection_length: 2.5
+#####################################################################
+#   Bed Heater
+#####################################################################
 
 [heater_bed]
 heater_pin: gpio23
-sensor_type: EPCOS 100K B57560G104F
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+#sensor_type:
 sensor_pin: gpio26
-control: pid
-pid_Kp: 54.027
-pid_Ki: 0.770
-pid_Kd: 948.182
+smooth_time: 3.0
+#max_power: 0.6                                                     # Only needed for 100w pads
 min_temp: 0
-max_temp: 130
+max_temp: 120
+control: pid                                                        # Do PID calibration after initial checks
+pid_kp: 68.453
+pid_ki: 2.749
+pid_kd: 426.122
 
-[printer]
-kinematics: corexy
-max_velocity: 500
-max_accel: 3000
-max_z_velocity: 25
-max_z_accel: 30
-square_corner_velocity: 6.0
+#####################################################################
+# Fan Control
+#####################################################################
 
 [heater_fan hotend_fan]
 pin: gpio21
+max_power: 1.0
+kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
+#fan_speed: 1.0                                                     # You can't PWM the delta fan unless using blue wire
 
 [fan]
 pin: gpio20
+max_power: 1.0
+kick_start_time: 0.5                                                # Depending on your fan, you may need to increase this value if your fan will not start
+off_below: 0.13
+cycle_time: 0.010
 
-#[heater_fan controller_fan]
-#pin: gpio22
-#heater: heater_bed
-#heater_temp: 45.0
+#####################################################################
+# Homing and Gantry Adjustment Routines
+#####################################################################
 
-[temperature_sensor chamber]
-sensor_type: EPCOS 100K B57560G104F
-sensor_pin: gpio27
-#min_temp:
-#max_temp:
+[idle_timeout]
+timeout: 1800
+
+[safe_z_home]
+home_xy_position: 120,120
+speed: 50.0
+z_hop: 5
+
+## To be used with BED_SCREWS_ADJUST
+[bed_screws]
+screw1: 60,5
+screw1_name: front screw
+screw2: 5,115
+screw2_name: back left
+screw3: 115,115
+screw3_name: back right
+
+#####################################################################
+# Probe
+#####################################################################
 
 #[probe]
 ##	Inductive Probe - If you use this section , please comment the [bltouch] section
@@ -182,45 +243,53 @@ sensor_pin: gpio27
 #sensor_pin: gpio25
 #control_pin: gpio13 # Reuse z endstop pin
 
-#[neopixel board_rgb]
+#####################################################################
+# Neopixel
+#####################################################################
+
+#[neopixel caselight]
 #pin: gpio29
 #chain_count: 1
-#color_order: GRB
+#color_order: GRBW
 #initial_RED: 0.3
 #initial_GREEN: 0.3
 #initial_BLUE: 0.3
+#initial_WHITE: 0.3
 
-[idle_timeout]
-timeout: 1800
+#####################################################################
+# Filament Sensor
+#####################################################################
 
-[safe_z_home]
-home_xy_position: 120,120
-speed: 50.0
-z_hop: 5
+[filament_switch_sensor runout_sensor]
+switch_pin: ^gpio10
+pause_on_runout: True
 
+#####################################################################
+# Chamber Temperature Sensor
+#####################################################################
 
-# Tool to help adjust bed leveling screws. One may define a
-# [bed_screws] config section to enable a BED_SCREWS_ADJUST g-code
-# command.
-[bed_screws]
-screw1: 65,5
-screw1_name: front screw
-screw2: 10,110
-screw2_name: back left
-screw3: 120,110
-screw3_name: back right
+[temperature_sensor chamber]
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+#sensor_type:
+sensor_pin: gpio27
+#min_temp:
+#max_temp:
 
+#####################################################################
+# Macros
+#####################################################################
 
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
 gcode:
     G28                            ; home all axes
+    G90                            ; absolute positioning    
     G1 Z20 F3000                   ; move nozzle away from bed
    
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customize for your slicer of choice
 gcode:
-
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-4.0 F3600                 ; retract filament
@@ -250,13 +319,13 @@ gcode:
         {% set z_safe = max_z - printer.toolhead.position.z %}
     {% endif %}
 
-    G0 Z{z_safe} F3600    ; move nozzle up
-    G0 X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
+    G0 Z{z_safe} F3600             ; move nozzle up
+    G0 X{x_safe} Y{y_safe} F20000  ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G90                            ; absolute positioning
     G0 X60 Y{max_y} F3600          ; park nozzle at rear
-	
+  
 [gcode_macro LOAD_FILAMENT]
 gcode:
    M83                            ; set extruder to relative
@@ -271,5 +340,4 @@ gcode:
    G1 E-40 F1800                  ; retract some, but not too much or it will jam
    M82                            ; set extruder to absolute
 
-#[include v0_display.cfg]
-#[include bedScrewMenu.cfg]
+[include mainsail.cfg]


### PR DESCRIPTION
I brought some improvements to the configuration provided in this repository.
Those improvements are based on the latest recommendations from Klipper developers and changes made upstream : 

- Disable TMC2209 interpolation and use 32 microsteps instead of 16 (more precision, no more noise)
- Updated macros
- Added comments
- Sensor_type agnostic, let the user choose which sensor he has
- Don't use hold_current as it is not recommended anymore
- Disable stealthchop by default (less precise, no more benefit between this and using 32 microsteps)
- Updated bed_screws locations